### PR TITLE
Add section number to query

### DIFF
--- a/fzman
+++ b/fzman
@@ -77,5 +77,16 @@ function _fzf_preview() {
 		--bind "enter:execute(awk '{print \$1}' <<< {1} | xargs -I@ -- man @ 2>/dev/null)"
 }
 
-_main "${@}"
+# NOTE: Maybe this conditional is a bit strange, but this is for a
+# compatibility about old version's bash. In old version it causes unbound
+# variable error when use parameter expantion with an empty array with `set -o
+# nounset` or `set -u` option. It is also same about potential parameters.
+#
+# A old version of bash, which is installed by default on macOS Big Sur, is
+# 3.2.57(1).
+if [[ $# == 0 ]]; then
+	_main
+else
+	_main "${@}"
+fi
 exit $?

--- a/fzman
+++ b/fzman
@@ -67,14 +67,53 @@ function _main() {
 }
 
 function _select_manual() {
-	man -k "${@}" | awk '{print $1}' | sort | uniq | _fzf_preview
+	man -k "${@}" | sed 's/ * - .*//g' | _fzf_preview
+}
+
+# Map apropos's output to a comman line argument(query) for man.
+entry2query() {
+	local -r entry="${1}"
+
+	case "${entry}" in
+	*,*)
+		# i.g. "command(1), cmd(1)"
+		entry2query "${entry/,*/}"
+		;;
+	*\ \(*)
+		# i.g. "command (1)"
+		read -ra queries <<<"${entry}"
+
+		local -r section="${queries[1]//[()]/}"
+		local -r name="${queries[0]}"
+
+		echo "${section} ${name}"
+		;;
+	*\(*)
+		# i.g. "command(1)"
+		entry2query "${entry/\(/ (}"
+		;;
+	*)
+		echo "${entry}"
+		;;
+	esac
 }
 
 function _fzf_preview() {
-	LANG=C fzf --layout reverse \
+	# Export a function to call it in sub bash process for fzf's
+	# `--preview` option.
+	export -f entry2query
+	local -r lookup='entry2query {} | xargs -n2 -- man 2>/dev/null'
+
+	# Specify `bash` as a subprocess for fzf `--preview` option to call a
+	# bash's expoterd shell function in the subprocess. Only bash can
+	# call the function, but the shell, which is invoked as fzf
+	# `--preview`'s subprocess, is described in `SEHLL` environment
+	# variable. So maybe not bash shell is called as the shell if a user
+	# use another shell as login shell.
+	SHELL=bash LANG=C fzf --layout reverse \
 		--prompt="${PROMPT}" \
-		--preview "awk '{print \$1}' <<< {1} | xargs -I@ -- man @ 2>/dev/null" \
-		--bind "enter:execute(awk '{print \$1}' <<< {1} | xargs -I@ -- man @ 2>/dev/null)"
+		--preview "${lookup}" \
+		--bind "enter:execute(${lookup})"
 }
 
 # NOTE: Maybe this conditional is a bit strange, but this is for a

--- a/fzman
+++ b/fzman
@@ -102,7 +102,7 @@ function _fzf_preview() {
 	# Export a function to call it in sub bash process for fzf's
 	# `--preview` option.
 	export -f entry2query
-	local -r lookup='entry2query {} | xargs -n2 -- man 2>/dev/null'
+	local -r lookup='entry2query {} | xargs -n2 -- man'
 
 	# Specify `bash` as a subprocess for fzf `--preview` option to call a
 	# bash's expoterd shell function in the subprocess. Only bash can
@@ -112,7 +112,7 @@ function _fzf_preview() {
 	# use another shell as login shell.
 	SHELL=bash LANG=C fzf --layout reverse \
 		--prompt="${PROMPT}" \
-		--preview "${lookup}" \
+		--preview "${lookup} 2>/dev/null" \
 		--bind "enter:execute(${lookup})"
 }
 

--- a/fzman
+++ b/fzman
@@ -110,10 +110,11 @@ function _fzf_preview() {
 	# `--preview`'s subprocess, is described in `SEHLL` environment
 	# variable. So maybe not bash shell is called as the shell if a user
 	# use another shell as login shell.
-	SHELL=bash LANG=C fzf --layout reverse \
+	SHELL=bash LANG=C fzf \
+		--layout=reverse \
 		--prompt="${PROMPT}" \
-		--preview "${lookup} 2>/dev/null" \
-		--bind "enter:execute(${lookup})"
+		--preview="${lookup} 2>/dev/null" \
+		--bind="enter:execute(${lookup})"
 }
 
 # NOTE: Maybe this conditional is a bit strange, but this is for a


### PR DESCRIPTION
There are some man entry which have same name but different section number. For example `cat (1)` and `cat (1p)`. They  have different contents each other so we should identify them. To resolve the problem add section number to man command query in addition to command name.

Also add compatibilities for old version of bash or another version of apropos. They are used on macOS (Big Sur) by default.